### PR TITLE
Deal with end points that can not be deserialized

### DIFF
--- a/author/README.pod
+++ b/author/README.pod
@@ -12,8 +12,8 @@ individual sections.
 The YAML files in the C<author/sections/> directory have lines
 like this:
 
-    - SUB: HTTP_METHOD PATH
-    - SUB: RETURN = HTTP_METHOD PATH?
+    - SUB: HTTP_METHOD PATH [NS]
+    - SUB: RETURN = HTTP_METHOD PATH? [NS]
 
 =head2 SUB
 
@@ -45,6 +45,10 @@ be injected in place of C<:bar>.
 
 If the PATH ends with a C<?> then this signifies that the API
 endpoint accepts query parameters.
+
+=head2 NS
+
+NS "No Serialize" Just return raw contents do not try to serialize it.
 
 =head1 GENERATING
 

--- a/author/generate.pl
+++ b/author/generate.pl
@@ -26,9 +26,9 @@ foreach my $section_name (keys %$section_pack) {
     foreach my $sub (keys %$endpoint_pack) {
         my $spec = $endpoint_pack->{$sub};
 
-        my ($return, $method, $path, $params_ok);
-        if ($spec =~ m{^(?:(\S+) = |)(GET|POST|PUT|DELETE) (\S+?)(\??)$}) {
-            ($return, $method, $path, $params_ok) = ($1, $2, $3, $4);
+        my ($return, $method, $path, $params_ok, $noserialize);
+        if ($spec =~ m{^(?:(\S+) = |)(GET|POST|PUT|DELETE) (\S+?)(\??)(?: (NS)|)$}) {
+            ($return, $method, $path, $params_ok, $noserialize) = ($1, $2, $3, $4, $5);
         }
         else {
             die "Invalid spec ($sub): $spec";
@@ -59,7 +59,13 @@ foreach my $section_name (keys %$section_pack) {
         print ");\n\n";
 
         print "Sends a C<$method> request to C<$path>";
-        print " and returns the decoded/deserialized response body" if $return;
+        if ($return) {
+            if ($noserialize) {
+                print " and returns the raw response body";
+            } else {
+                print " and returns the decoded/deserialized response body";
+            }
+        }
         print ".\n\n=cut\n\n";
 
         print "sub $sub {\n";
@@ -106,6 +112,10 @@ foreach my $section_name (keys %$section_pack) {
         print 'return ' if $return;
         print "\$self->_call_rest_method( '$method_sub', \$path";
         print ", ( defined(\$params) ? \$params : () )" if $params_ok;
+        if ($noserialize) {
+            print ",undef" if ! $params_ok;
+            print ",{'deserializer' => undef}";
+        }
         print " );\n";
         print "    return;\n" if !$return;
         print "}\n\n";

--- a/author/sections/users.yml
+++ b/author/sections/users.yml
@@ -3,7 +3,7 @@
 - user: user = GET /users/:user_id
 - create_user: POST /users?
 - edit_user: PUT /users/:user_id?
-- delete_user: user = DELETE /users/:user_id
+- delete_user: DELETE /users/:user_id NS
 - current_user: user = GET /user
 - current_user_ssh_keys: keys = GET /user/keys
 - user_ssh_keys: keys = GET /users/:user_id/keys
@@ -27,8 +27,8 @@
 - create_user_email: email = POST /users/:user_id/emails?
 - delete_current_user_email: DELETE /user/emails/:email_id
 - delete_user_email: DELETE /users/:user_id/emails/:email_id
-- block_user: POST /users/:user_id/block
-- unblock_user: POST /users/:user_id/unblock
+- block_user: status = POST /users/:user_id/block NS
+- unblock_user: status = POST /users/:user_id/unblock NS
 - user_impersonation_tokens: tokens = GET /users/:user_id/impersonation_tokens?
 - user_impersonation_token: token = GET /users/:user_id/impersonation_tokens/:impersonation_token_id
 - create_user_impersonation_token: token = POST /users/:user_id/impersonation_tokens?

--- a/lib/GitLab/API/v4.pm
+++ b/lib/GitLab/API/v4.pm
@@ -7070,11 +7070,11 @@ sub edit_user {
 
 =head2 delete_user
 
-    my $user = $api->delete_user(
+    $api->delete_user(
         $user_id,
     );
 
-Sends a C<DELETE> request to C</users/:user_id> and returns the decoded/deserialized response body.
+Sends a C<DELETE> request to C</users/:user_id>.
 
 =cut
 
@@ -7083,7 +7083,8 @@ sub delete_user {
     croak 'delete_user must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to delete_user must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('users/%s', (map { uri_escape($_) } @_));
-    return $self->_call_rest_method( 'delete', $path );
+    $self->_call_rest_method( 'delete', $path,undef,{'deserializer' => undef} );
+    return;
 }
 
 =head2 current_user
@@ -7519,11 +7520,11 @@ sub delete_user_email {
 
 =head2 block_user
 
-    $api->block_user(
+    my $status = $api->block_user(
         $user_id,
     );
 
-Sends a C<POST> request to C</users/:user_id/block>.
+Sends a C<POST> request to C</users/:user_id/block> and returns the raw response body.
 
 =cut
 
@@ -7532,17 +7533,16 @@ sub block_user {
     croak 'block_user must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to block_user must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('users/%s/block', (map { uri_escape($_) } @_));
-    $self->_call_rest_method( 'post', $path );
-    return;
+    return $self->_call_rest_method( 'post', $path,undef,{'deserializer' => undef} );
 }
 
 =head2 unblock_user
 
-    $api->unblock_user(
+    my $status = $api->unblock_user(
         $user_id,
     );
 
-Sends a C<POST> request to C</users/:user_id/unblock>.
+Sends a C<POST> request to C</users/:user_id/unblock> and returns the raw response body.
 
 =cut
 
@@ -7551,8 +7551,7 @@ sub unblock_user {
     croak 'unblock_user must be called with 1 arguments' if @_ != 1;
     croak 'The #1 argument ($user_id) to unblock_user must be a scalar' if ref($_[0]) or (!defined $_[0]);
     my $path = sprintf('users/%s/unblock', (map { uri_escape($_) } @_));
-    $self->_call_rest_method( 'post', $path );
-    return;
+    return $self->_call_rest_method( 'post', $path,undef,{'deserializer' => undef} );
 }
 
 =head2 user_impersonation_tokens

--- a/t/regression.t
+++ b/t/regression.t
@@ -38,4 +38,16 @@ while ($api->project( $project_id )) {
 }
 ok( 1, 'project deleted' );
 
+my $create_user = $api->create_user({'username'=>'maryp','email'=>'maryp@test.example.com','password'=>'d5fzHF7tfgh','name'=>'Mary Poppins'});
+ok( 1, 'user created' );
+my $found_user = $api->users({'username'=>'maryp'});
+ok( $found_user, 'user found' );
+my $user_id = $found_user->[0]->{'id'};
+my $block_user = $api->block_user($user_id);
+ok( $block_user eq 'true', 'user blocked' );
+$block_user = $api->unblock_user($user_id);
+ok( $block_user eq 'true', 'user unblocked' );
+$api->delete_user($user_id);
+ok( 1, 'user deleted' );
+
 done_testing;


### PR DESCRIPTION
- Updated generate.pl so on reading a configuration line with "NS" as the last parameter it will generate
  a function where the raw response body is returned. (No decoded/deserialized of the response body is done).
  This stops errors being return on those rest end points that don't return a valid JSON response line.
- Updated delete_user,block_user and unblock_user to use NS