### PR TITLE
Add trigger_pipeline method

### DIFF
--- a/author/config.yml
+++ b/author/config.yml
@@ -114,6 +114,9 @@ sections:
 - pipeline_triggers:
     head: Pipeline triggers
     doc_url: https://docs.gitlab.com/ce/api/pipeline_triggers.html
+- trigger_pipeline:
+    head: Trigger Pipeline
+    doc_url: https://docs.gitlab.com/ce/ci/triggers/#triggering-a-pipeline
 - pipeline_schedules:
     head: Pipeline schedules
     doc_url: https://docs.gitlab.com/ce/api/pipeline_schedules.html

--- a/author/footer.pm
+++ b/author/footer.pm
@@ -75,6 +75,10 @@ Luc Didry <lucE<64>framasoft.org>
 
 Kieren Diment <kieren.dimentE<64>staples.com.au>
 
+=item *
+
+Dmitry Frolov <dmitry.frolovE<64>gmail.com>
+
 =back
 
 =head1 ACKNOWLEDGEMENTS

--- a/author/sections/trigger_pipeline.yml
+++ b/author/sections/trigger_pipeline.yml
@@ -1,0 +1,21 @@
+---
+- method: trigger_pipeline
+  spec: pipeline = POST projects/:project_id/trigger/pipeline?
+  note: |
+    The API authentication token (L</private_token> or L</access_token>
+    parameters in a constructor) is not needed when using this method, however
+    You must pass trigger token (generated at the trigger creation) as C<token>
+    field and git ref name as C<ref> field in the C<%params> hash. You can also
+    pass variables to be set in a pipeline in the C<variables> field. Example:
+
+        my $pipeline = $api->trigger_pipeline(
+            $project_id,
+            {
+                token => 'd69dba9162ab6ac72fa0993496286ada',
+                'ref' => 'master',
+                variables => {
+                    variable1 => 'value1',
+                    variable2 => 'value2'
+                }
+            }
+        );


### PR DESCRIPTION
This adds a method to create pipeline using a pipeline trigger. The method is not documented in API docs, but it is documented here: https://docs.gitlab.com/ce/ci/triggers/#triggering-a-pipeline