### PR TITLE
add container_registry methods

### DIFF
--- a/author/config.yml
+++ b/author/config.yml
@@ -21,6 +21,9 @@ sections:
 - commits:
     head: Commits
     doc_url: https://docs.gitlab.com/ce/api/commits.html
+- container_registry:
+    head: Container Registry
+    doc_url: https://docs.gitlab.com/ee/api/container_registry.html
 - custom_attributes:
     head: Custom Attributes
     doc_url: https://docs.gitlab.com/ce/api/custom_attributes.html

--- a/author/sections/container_registry.yml
+++ b/author/sections/container_registry.yml
@@ -1,0 +1,8 @@
+---
+- registry_repositories_in_project: registry_repositories = GET projects/:id/registry/repositories?
+- registry_repositories_in_group: registry_repositories = GET groups/:id/registry/repositories?
+- delete_registry_repository: DELETE projects/:id/registry/repositories/:repository_id
+- registry_repository_tags: tags = GET projects/:id/registry/repositories/:repository_id/tags
+- registry_repository_tag: tag = GET projects/:id/registry/repositories/:repository_id/tags/:tag_name
+- delete_registry_repository_tag: DELETE projects/:id/registry/repositories/:repository_id/tags/:tag_name
+- bulk_delete_registry_repository_tags: DELETE projects/:id/registry/repositories/:repository_id/tags?


### PR DESCRIPTION
Hey!

I recently needed to access the Container Registry API
https://docs.gitlab.com/ee/api/container_registry.html 
to bulk-delete old containers. As this API was not yet implemented in GitLab::API::v4, I have added the needed config (btw, nice way to "program" an API client!)

I'm using a local copy including my patch, and can now successfully access the Container Registry API.

So please review / merge my patch!

Greetings,
domm

