### PR TITLE
Use JSON::MaybeXS instead of JSON

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ requires 'Types::Common::String' => '1.002001';
 requires 'Types::Common::Numeric' => '1.002001';
 requires 'Log::Any' => '1.703';
 requires 'Carp' => 0;
-requires 'JSON' => '2.59';
+requires 'JSON::MaybeXS' => '1.003007';
 
 # Used by GitLab::API::v4::RESTClient.
 requires 'HTTP::Tiny' => '0.059';

--- a/lib/GitLab/API/v4/Config.pm
+++ b/lib/GitLab/API/v4/Config.pm
@@ -236,9 +236,7 @@ sub configure {
         '-stdio', '-verbatim',
     );
 
-    my $json = JSON->new
-        ->pretty
-        ->canonical
+    my $json = JSON::MaybeXS->new(pretty => 1, canonical => 1)
     ->encode({
         $url           ? (url=>$url) : (),
         $private_token ? (private_token=>$private_token) : (),

--- a/lib/GitLab/API/v4/Config.pm
+++ b/lib/GitLab/API/v4/Config.pm
@@ -28,7 +28,7 @@ L</SYNOPSIS>.
 
 use Getopt::Long;
 use IO::Prompter;
-use JSON;
+use JSON::MaybeXS;
 use Log::Any qw( $log );
 use Path::Tiny;
 use Types::Common::String -types;

--- a/lib/GitLab/API/v4/Mock/RESTClient.pm
+++ b/lib/GitLab/API/v4/Mock/RESTClient.pm
@@ -18,7 +18,7 @@ This module is used by L<GitLab::API::v4::Mock>.
 =cut
 
 use GitLab::API::v4::Mock::Engine;
-use JSON;
+use JSON::MaybeXS;
 use URI;
 
 use Moo;

--- a/lib/GitLab/API/v4/RESTClient.pm
+++ b/lib/GitLab/API/v4/RESTClient.pm
@@ -110,7 +110,7 @@ has json => (
     isa => HasMethods[ 'encode', 'decode' ],
 );
 sub _build_json {
-    return JSON->new->utf8->allow_nonref();
+    return JSON::MaybeXS->new(utf8 => 1, allow_nonref => 1);
 }
 
 has http_tiny_request => (

--- a/lib/GitLab/API/v4/RESTClient.pm
+++ b/lib/GitLab/API/v4/RESTClient.pm
@@ -9,9 +9,9 @@ GitLab::API::v4::RESTClient - The HTTP client that does the heavy lifting.
 
 =head1 DESCRIPTION
 
-Currently this class uses L<HTTP::Tiny> and L<JSON> to do its job.  This may
-change, and the interface may change, so documentation is lacking in order
-to not mislead people.
+Currently this class uses L<HTTP::Tiny> and L<JSON::MaybeXS> to do its job.
+This may change, and the interface may change, so documentation is lacking in
+order to not mislead people.
 
 If you do want to customize how this class works then take a look at the
 source.
@@ -40,7 +40,7 @@ and you will have encountered an error when making the request
 use Carp qw();
 use HTTP::Tiny::Multipart;
 use HTTP::Tiny;
-use JSON;
+use JSON::MaybeXS;
 use Log::Any qw( $log );
 use Path::Tiny;
 use Try::Tiny;

--- a/script/gitlab-api-v4
+++ b/script/gitlab-api-v4
@@ -120,7 +120,7 @@ my $data = $api->$method(
 $data = $data->all() if $all;
 
 binmode STDOUT, ':utf8';
-my $json = JSON->new->allow_nonref();
+my $json = JSON::MaybeXS->new(allow_nonref => 1);
 $json->pretty() if $pretty;
 $json->canonical() if $canonical;
 print $json->encode( $data );

--- a/script/gitlab-api-v4
+++ b/script/gitlab-api-v4
@@ -4,7 +4,7 @@ use strictures 2;
 use GitLab::API::v4::Config;
 use GitLab::API::v4::Constants qw( :all );
 use GitLab::API::v4;
-use JSON;
+use JSON::MaybeXS;
 use Log::Any qw( $log );
 use Log::Any::Adapter::Screen;
 use Log::Any::Adapter;
@@ -204,14 +204,14 @@ See L<GitLab::API::v4::Paginator/all> for details.
     --pretty
     -p
 
-Enables the L<JSON/pretty> feature.
+Enables the L<JSON::PP/pretty> feature.
 
 =head2 canonical
 
     --canonical
     -c
 
-Enables the L<JSON/canonical> feature.
+Enables the L<JSON::PP/canonical> feature.
 
 =head1 API METHOD
 

--- a/t/gitlab-api-v4.t
+++ b/t/gitlab-api-v4.t
@@ -5,9 +5,9 @@ use Test2::Require::AuthorTesting;
 use Test2::V0;
 
 use IPC::Cmd qw();
-use JSON::MaybeXS qw(JSON);
+use JSON::MaybeXS qw();
 
-my $json = JSON->new->allow_nonref();
+my $json = JSON::MaybeXS->new(allow_nonref => 1);
 
 my $project = run('create-project', 'name:test-gitlab-api-v4');
 run('delete-project', $project->{id});

--- a/t/gitlab-api-v4.t
+++ b/t/gitlab-api-v4.t
@@ -5,7 +5,7 @@ use Test2::Require::AuthorTesting;
 use Test2::V0;
 
 use IPC::Cmd qw();
-use JSON qw();
+use JSON::MaybeXS qw(JSON);
 
 my $json = JSON->new->allow_nonref();
 


### PR DESCRIPTION
JSON::MaybeXS prefers and allows use of Cpanel::JSON::XS as the backend, which fixes [many issues](https://metacpan.org/pod/Cpanel::JSON::XS#cPanel-fork) in JSON::XS (some of which are also fixed in JSON::PP). It is also a much simpler wrapper than JSON.

The first commit simply replaces usage of JSON with JSON::MaybeXS, using its drop-in JSON() sub. The second commit additionally changes to use the JSON::MaybeXS constructor which is somewhat nicer.