### PR TITLE
🔥 — Remove file renaming before upload

### DIFF
--- a/lib/GitLab/API/v4/RESTClient.pm
+++ b/lib/GitLab/API/v4/RESTClient.pm
@@ -126,7 +126,6 @@ sub request {
 
         # Might as well mask the filename, but leave the extension.
         my $filename = $file->basename(); # foo/bar.txt => bar.txt
-        $filename =~ s{^.*?(\.[^.]+|)}{upload$1}; # bar.txt => upload.txt
 
         my $data = {
             file => {


### PR DESCRIPTION
The current regex was broken:
```bash
luc@odysseus: /tmp % perl -e '$filename = "file.js" ;$filename =~ s{^.*?(\.[^.]+|)}{upload$1};print $filename, "\n";'
uploadfile.js
```

With correction:
```bash
luc@odysseus: /tmp % perl -e '$filename = "file.js" ;$filename =~ s{^.*?(\.[^.]+)}{upload$1};print $filename, "\n";'
upload.js
```