### PR TITLE
test script using current perl

### DIFF
--- a/t/gitlab-api-v4.t
+++ b/t/gitlab-api-v4.t
@@ -17,10 +17,8 @@ ok( 1, 'made it to the end' );
 done_testing;
 
 sub run {
-    local $ENV{PERL5LIB} = 'lib';
-
     my($ok, $error, $full, $stdout, $stderr) =
-        IPC::Cmd::run( command => ['script/gitlab-api-v4', @_] );
+        IPC::Cmd::run( command => [$^X, '-I', 'lib', 'script/gitlab-api-v4', @_] );
 
     if ($ok) {
         $stdout = join('',@$stdout);


### PR DESCRIPTION
Instead of relying on the environment, call the script using the
currently running perl.  This also provides an easy way to add lib to
the `@INC` path, rather than overriding `PERL5LIB`, which won't play nice
with local::lib.