### PR TITLE
Allow multi-line arguments for gitlab-api-v4

### DIFF
--- a/script/gitlab-api-v4
+++ b/script/gitlab-api-v4
@@ -79,7 +79,7 @@ while (@ARGV) {
     my $arg = shift @ARGV;
     next if $arg eq '--';
 
-    if ($arg =~ m{^([^:]+):(.*)$}) {
+    if ($arg =~ m{^([^:]+):(.*)$}s) {
         my ($key, $value) = ($1, $2);
 
         $key =~ s{-}{_}g;


### PR DESCRIPTION
Usecase: when updating a release, I want to be able to update the description with a multi-line text, which is not currently possible.