### PR TITLE
Close #53 - Add PUT multipart support

### DIFF
--- a/author/generate.pl
+++ b/author/generate.pl
@@ -121,6 +121,12 @@ foreach my $section_name (keys %$section_pack) {
             print "    \$options->{$params_key} = \$params if defined \$params;\n";
         }
 
+        my @code;
+        @code = split /\n/, $endpoint->{code} if $endpoint->{code};
+        foreach my $line (@code) {
+            print "    $line\n";
+        }
+
         print '    ';
         print 'return ' if $return;
         print "\$self->_call_rest_client( '$verb', '$path', [\@_], \$options );\n";

--- a/author/sections/projects.yml
+++ b/author/sections/projects.yml
@@ -6,6 +6,10 @@
 - create_project: project = POST projects?
 - create_project_for_user: POST projects/user/:user_id?
 - edit_project: PUT projects/:project_id?
+- method: edit_project_multipart
+  spec: PUT projects/:project_id?
+  note: The request will have "multipart/form-data" header set for uploading files.
+  code: $options->{content}->{file} = $params;
 - fork_project: POST projects/:project_id/fork?
 - project_forks: forks = GET projects/:project_id/forks?
 - start_project: project = POST projects/:project_id/star

--- a/lib/GitLab/API/v4.pm
+++ b/lib/GitLab/API/v4.pm
@@ -7321,7 +7321,6 @@ sub create_project_for_user {
     $api->edit_project(
         $project_id,
         \%params,
-        \%params_multipart,
     );
 
 Sends a C<PUT> request to C<projects/:project_id>.
@@ -7330,21 +7329,39 @@ Sends a C<PUT> request to C<projects/:project_id>.
 
 sub edit_project {
     my $self = shift;
-    croak 'edit_project must be called with 1 to 3 arguments' if @_ < 1 or @_ > 3;
+    croak 'edit_project must be called with 1 to 2 arguments' if @_ < 1 or @_ > 2;
     croak 'The #1 argument ($project_id) to edit_project must be a scalar' if ref($_[0]) or (!defined $_[0]);
-    croak 'The #2 argument (\%params) to edit_project must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
-    croak 'The last argument (\%params_multipart) to edit_project must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
-    my $params_multipart = (@_ == 3) ? pop() : undef;
+    croak 'The last argument (\%params) to edit_project must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
     my $params = (@_ == 2) ? pop() : undef;
     my $options = {};
     $options->{decode} = 0;
     $options->{content} = $params if defined $params;
-    $self->_call_rest_client( 'PUT', 'projects/:project_id', [$_[0]], $options );
+    $self->_call_rest_client( 'PUT', 'projects/:project_id', [@_], $options );
+    return;
+}
 
-    if (keys %$params_multipart) {
-        $options->{content}->{file} = $params_multipart ;
-        $self->_call_rest_client( 'PUT', 'projects/:project_id', [$_[0]], $options );
-    }
+=item edit_project_multipart
+
+    $api->edit_project_multipart(
+        $project_id,
+        \%params,
+    );
+
+Sends a C<PUT> request to C<projects/:project_id>.
+
+The request will have "multipart/form-data" header set for uploading files.
+=cut
+
+sub edit_project_multipart {
+    my $self = shift;
+    croak 'edit_project_multipart must be called with 1 to 2 arguments' if @_ < 1 or @_ > 2;
+    croak 'The #1 argument ($project_id) to edit_project_multipart must be a scalar' if ref($_[0]) or (!defined $_[0]);
+    croak 'The last argument (\%params) to edit_project_multipart must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
+    my $params = (@_ == 2) ? pop() : undef;
+    my $options = {};
+    $options->{decode} = 0;
+    $options->{content}->{file} = $params if defined $params;
+    $self->_call_rest_client( 'PUT', 'projects/:project_id', [@_], $options );
     return;
 }
 

--- a/lib/GitLab/API/v4.pm
+++ b/lib/GitLab/API/v4.pm
@@ -7321,6 +7321,7 @@ sub create_project_for_user {
     $api->edit_project(
         $project_id,
         \%params,
+        \%params_multipart,
     );
 
 Sends a C<PUT> request to C<projects/:project_id>.
@@ -7329,14 +7330,21 @@ Sends a C<PUT> request to C<projects/:project_id>.
 
 sub edit_project {
     my $self = shift;
-    croak 'edit_project must be called with 1 to 2 arguments' if @_ < 1 or @_ > 2;
+    croak 'edit_project must be called with 1 to 3 arguments' if @_ < 1 or @_ > 3;
     croak 'The #1 argument ($project_id) to edit_project must be a scalar' if ref($_[0]) or (!defined $_[0]);
-    croak 'The last argument (\%params) to edit_project must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
+    croak 'The #2 argument (\%params) to edit_project must be a hash ref' if defined($_[1]) and ref($_[1]) ne 'HASH';
+    croak 'The last argument (\%params_multipart) to edit_project must be a hash ref' if defined($_[2]) and ref($_[2]) ne 'HASH';
+    my $params_multipart = (@_ == 3) ? pop() : undef;
     my $params = (@_ == 2) ? pop() : undef;
     my $options = {};
     $options->{decode} = 0;
     $options->{content} = $params if defined $params;
-    $self->_call_rest_client( 'PUT', 'projects/:project_id', [@_], $options );
+    $self->_call_rest_client( 'PUT', 'projects/:project_id', [$_[0]], $options );
+
+    if (keys %$params_multipart) {
+        $options->{content}->{file} = $params_multipart ;
+        $self->_call_rest_client( 'PUT', 'projects/:project_id', [$_[0]], $options );
+    }
     return;
 }
 


### PR DESCRIPTION
To use GitLab's API v4, in order to change a  project's avatar, the request needs to be submitted via PUT  with `Content-Type: multipart/form-data` header.

REF: https://docs.gitlab.com/ee/api/projects.html#upload-a-project-avatar

- - -

- Opt'd not to include `content-type:` in the request, in order to reduce the amount of libraries needed
  - This logic should be done on the server side to validate the request
- Opt'd to use `sub edit_project`, rather than making its a new one (to keep the naming convention)
- Re-used as much logic which was already there as there was support already already upload a single file (just via a different method)
  - Upon uploading a file, it would replace any other content being submitted (aka the JSON)
  - Which is why `_call_rest_client` happens twice
