### PR TITLE
Add run_pipeline_schedule support

### DIFF
--- a/author/sections/pipeline_schedules.yml
+++ b/author/sections/pipeline_schedules.yml
@@ -4,6 +4,7 @@
 - create_pipeline_schedule: schedule = POST projects/:project_id/pipeline_schedules?
 - edit_pipeline_schedule: schedule = PUT projects/:project_id/pipeline_schedules/:pipeline_schedule_id?
 - take_ownership_of_pipeline_schedule: schedule = POST projects/:project_id/pipeline_schedules/:pipeline_schedule_id/take_ownership
+- run_pipeline_schedule: variable = POST projects/:project_id/pipeline_schedules/:pipeline_schedule_id/play
 - delete_pipeline_schedule: schedule = DELETE projects/:project_id/pipeline_schedules/:pipeline_schedule_id
 - create_pipeline_schedule_variable: variable = POST projects/:project_id/pipeline_schedules/:pipeline_schedule_id/variables?
 - edit_pipeline_schedule_variable: variable = PUT projects/:project_id/pipeline_schedules/:pipeline_schedule_id/variables/:variable_key?

--- a/lib/GitLab/API/v4.pm
+++ b/lib/GitLab/API/v4.pm
@@ -7086,6 +7086,26 @@ sub take_ownership_of_pipeline_schedule {
     return $self->_call_rest_client( 'POST', 'projects/:project_id/pipeline_schedules/:pipeline_schedule_id/take_ownership', [@_], $options );
 }
 
+=item run_pipeline_schedule
+
+    my $variable = $api->run_pipeline_schedule(
+        $project_id,
+        $pipeline_schedule_id,
+    );
+
+Sends a C<POST> request to C<projects/:project_id/pipeline_schedules/:pipeline_schedule_id/play> and returns the decoded response content.
+
+=cut
+
+sub run_pipeline_schedule {
+    my $self = shift;
+    croak 'run_pipeline_schedule must be called with 2 arguments' if @_ != 2;
+    croak 'The #1 argument ($project_id) to run_pipeline_schedule must be a scalar' if ref($_[0]) or (!defined $_[0]);
+    croak 'The #2 argument ($pipeline_schedule_id) to run_pipeline_schedule must be a scalar' if ref($_[1]) or (!defined $_[1]);
+    my $options = {};
+    return $self->_call_rest_client( 'POST', 'projects/:project_id/pipeline_schedules/:pipeline_schedule_id/play', [@_], $options );
+}
+
 =item delete_pipeline_schedule
 
     my $schedule = $api->delete_pipeline_schedule(


### PR DESCRIPTION
Using GitLab's API v4 (since GitLab v12.8), it is possible to manually run a scheduled pipeline job.

REF https://docs.gitlab.com/ee/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately