### PR TITLE
Add verify_SSL=>1 to HTTP::Tiny to verify https server identity

### DIFF
--- a/lib/GitLab/API/v4/RESTClient.pm
+++ b/lib/GitLab/API/v4/RESTClient.pm
@@ -102,7 +102,7 @@ has http_tiny => (
     isa => InstanceOf[ 'HTTP::Tiny' ],
 );
 sub _build_http_tiny {
-    return HTTP::Tiny->new();
+    return HTTP::Tiny->new( verify_SSL => 1 );
 }
 
 has json => (

--- a/lib/GitLab/API/v4/WWWClient.pm
+++ b/lib/GitLab/API/v4/WWWClient.pm
@@ -81,6 +81,7 @@ sub sign_in {
     my ($self, $username, $password) = @_;
 
     my $tiny = HTTP::Tiny->new(
+        verify_SSL => 1,
         max_redirect => 0,
     );
 
@@ -165,6 +166,7 @@ sub get {
     my ($self, $path) = @_;
 
     my $tiny = HTTP::Tiny->new(
+        verify_SSL => 1,
         max_redirect => 0,
     );
 


### PR DESCRIPTION
The `verify_SSL=>1` flag is missing from `HTTP::Tiny` in this distribution, and allows a network attacker to MITM connections to the GitLab server. This patch sets verify_SSL to 1 and will make request to GitLab servers without a valid certificate fail.

Problem has been verified using [mitmproxy](https://docs.mitmproxy.org/stable/howto-transparent/)

MITM test with fix
```sh
$ PERL5LIB="./lib" script/gitlab-api-v4 projects | wc -c
Error GETing https://gitlab.com/api/v4/projects (HTTP 599): Internal Exception SSL connection failed for gitlab.com: SSL connect ... at script/gitlab-api-v4 line 115.
0
```

MITM test without fix
```sh
$ PERL5LIB="./lib" script/gitlab-api-v4 projects | wc -c
86599
```
