### PR TITLE
Handle non-JSON results correctly

### DIFF
--- a/lib/GitLab/API/v4.pm
+++ b/lib/GitLab/API/v4.pm
@@ -4105,6 +4105,7 @@ sub job_artifacts {
     croak 'The #1 argument ($project_id) to job_artifacts must be a scalar' if ref($_[0]) or (!defined $_[0]);
     croak 'The #2 argument ($job_id) to job_artifacts must be a scalar' if ref($_[1]) or (!defined $_[1]);
     my $options = {};
+    $options->{decode} = 0;
     return $self->_call_rest_client( 'GET', 'projects/:project_id/jobs/:job_id/artifacts', [@_], $options );
 }
 

--- a/script/gitlab-api-v4
+++ b/script/gitlab-api-v4
@@ -119,11 +119,17 @@ my $data = $api->$method(
 
 $data = $data->all() if $all;
 
-binmode STDOUT, ':utf8';
+binmode STDOUT;
 my $json = JSON::MaybeXS->new(allow_nonref => 1);
 $json->pretty() if $pretty;
 $json->canonical() if $canonical;
-print $json->encode( $data );
+if (ref($data) eq 'ARRAY') {
+    binmode STDOUT, ':utf8';
+    print $json->encode( $data );
+}
+else {
+    print $data;
+}
 
 __END__
 


### PR DESCRIPTION
Hopefully fixes bluefeet/GitLab-API-v4#48

Requests that don't return JSON must not have their result touched in any way.

Other methods that are affected by this are archive and raw_file. Those already set decode to 0.